### PR TITLE
Support new issue URL aliases

### DIFF
--- a/dreditor.js
+++ b/dreditor.js
@@ -2572,7 +2572,11 @@ Drupal.dreditor.syntaxAutocomplete.prototype.suggestions.html = {
  */
 Drupal.dreditor.syntaxAutocomplete.prototype.suggestions.issue = function (needle) {
   var matches;
+  https://www.drupal.org/project/drupal/issues/3231503
   if (matches = needle.match('^https?://(?:www.)?drupal.org/node/([0-9]+)')) {
+    return '[#' + matches[1] + ']^';
+  }
+  if (matches = needle.match('^https?://(?:www.)?drupal.org/project/([a-z_]+)/issues/([0-9]+)')) {
     return '[#' + matches[1] + ']^';
   }
   return false;

--- a/dreditor.js
+++ b/dreditor.js
@@ -2577,7 +2577,7 @@ Drupal.dreditor.syntaxAutocomplete.prototype.suggestions.issue = function (needl
     return '[#' + matches[1] + ']^';
   }
   if (matches = needle.match('^https?://(?:www.)?drupal.org/project/([a-z_]+)/issues/([0-9]+)')) {
-    return '[#' + matches[1] + ']^';
+    return '[#' + matches[2] + ']^';
   }
   return false;
 };


### PR DESCRIPTION
Url aliases for issues are now in this format `https://www.drupal.org/project/drupal/issues/3231503`, so the suggestion doesn't work when you paste URLs in that format